### PR TITLE
feature: Allow the user to override selected element in sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 /src/routes/testdir
 /test-results
+bun.lockb

--- a/src/lib/sidebar/SidebarItem.svelte
+++ b/src/lib/sidebar/SidebarItem.svelte
@@ -14,9 +14,10 @@
     activeClass?: string;
     nonActiveClass?: string;
     aClass?: string;
+    active?: boolean;
   }
 
-  let { iconSlot, subtext, href, label, spanClass = 'ms-3', activeClass, nonActiveClass, aClass, class: className, ...restProps }: Props = $props();
+  let { iconSlot, subtext, href, label, spanClass = 'ms-3', activeClass, nonActiveClass, aClass, active, class: className, ...restProps }: Props = $props();
 
   const context = getContext<SidebarType>('sidebarContext') ?? {};
   let currentUrl = $state();
@@ -25,11 +26,11 @@
     currentUrl = $page.url.pathname;
   });
 
-  let aCls = $derived(currentUrl === href ? (activeClass ?? context.activeClass) : (nonActiveClass ?? context.nonActiveClass));
+  let aCls = $derived((active ?? currentUrl === href) ? (activeClass ?? context.activeClass) : (nonActiveClass ?? context.nonActiveClass));
 </script>
 
 <li class={className}>
-  <a {...restProps} {href} aria-current={currentUrl === href} class={twMerge(aCls, aClass)}>
+  <a {...restProps} {href} aria-current={active ?? currentUrl === href} class={twMerge(aCls, aClass)}>
     {#if iconSlot}
       {@render iconSlot()}
     {/if}
@@ -52,6 +53,7 @@
 @prop activeClass
 @prop nonActiveClass
 @prop aClass
+@prop active
 @prop class: className
 @prop ...restProps
 -->

--- a/src/routes/components/sidebar/+page.svelte
+++ b/src/routes/components/sidebar/+page.svelte
@@ -170,6 +170,52 @@
   {/snippet}
 </CodeWrapper>
 
+<H2>Override active element</H2>
+<CodeWrapper class="relative">
+  <Sidebar {activeClass} {nonActiveClass} class="p-2" asideClass="absolute top-6 left-6 z-40">
+    <SidebarGroup>
+      <SidebarItem label="Dashboard" href="/" active>
+        {#snippet iconSlot()}
+          <ChartOutline class="h-5 w-5 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white" />
+        {/snippet}
+      </SidebarItem>
+      <SidebarItem label="Kanban" {spanClass} active={false}>
+        {#snippet iconSlot()}
+          <GridSolid class="h-5 w-5 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white" />
+        {/snippet}
+        {#snippet subtext()}
+          <span class="ms-3 inline-flex items-center justify-center rounded-full bg-gray-200 px-2 text-sm font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300">Pro</span>
+        {/snippet}
+      </SidebarItem>
+      <SidebarItem label="Inbox" {spanClass} active={false}>
+        {#snippet iconSlot()}
+          <MailBoxSolid class="h-5 w-5 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white" />
+        {/snippet}
+        {#snippet subtext()}
+          <span class="ms-3 inline-flex h-3 w-3 items-center justify-center rounded-full bg-primary-200 p-3 text-sm font-medium text-primary-600 dark:bg-primary-900 dark:text-primary-200">3</span>
+        {/snippet}
+      </SidebarItem>
+      <SidebarItem label="Sidebar" href="/components/sidebar" active={false}>
+        {#snippet iconSlot()}
+          <UserSolid class="h-5 w-5 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white" />
+        {/snippet}
+      </SidebarItem>
+    </SidebarGroup>
+  </Sidebar>
+  <div class="h-96 overflow-scroll px-4 sm:ml-64">
+    <div class="rounded-lg border-2 border-dashed border-gray-200 p-4 dark:border-gray-700">
+      <PlusPlaceholder colnum={3} rownum={1} />
+      <PlusPlaceholder />
+      <PlusPlaceholder colnum={2} rownum={2} />
+      <PlusPlaceholder />
+      <PlusPlaceholder colnum={2} rownum={2} />
+    </div>
+  </div>
+  {#snippet codeblock()}
+    <HighlightCompo code={modules['./md/overriding-active-element.md'] as string} />
+  {/snippet}
+</CodeWrapper>
+
 <H2>Multi-level dropdown</H2>
 <CodeWrapper class="relative">
   <Sidebar class="p-2" asideClass="absolute top-6 left-6 z-40">

--- a/src/routes/components/sidebar/md/overriding-active-element.md
+++ b/src/routes/components/sidebar/md/overriding-active-element.md
@@ -1,0 +1,30 @@
+<Sidebar {activeClass} {nonActiveClass} class="p-2" asideClass="absolute top-6 left-6 z-40">
+<SidebarGroup>
+    <SidebarItem label="Dashboard" href="/" active>
+    {#snippet iconSlot()}
+        <ChartOutline class="h-5 w-5 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white" />
+    {/snippet}
+    </SidebarItem>
+    <SidebarItem label="Kanban" {spanClass} active={false}>
+    {#snippet iconSlot()}
+        <GridSolid class="h-5 w-5 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white" />
+    {/snippet}
+    {#snippet subtext()}
+        <span class="ms-3 inline-flex items-center justify-center rounded-full bg-gray-200 px-2 text-sm font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300">Pro</span>
+    {/snippet}
+    </SidebarItem>
+    <SidebarItem label="Inbox" {spanClass} active={false}>
+    {#snippet iconSlot()}
+        <MailBoxSolid class="h-5 w-5 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white" />
+    {/snippet}
+    {#snippet subtext()}
+        <span class="ms-3 inline-flex h-3 w-3 items-center justify-center rounded-full bg-primary-200 p-3 text-sm font-medium text-primary-600 dark:bg-primary-900 dark:text-primary-200">3</span>
+    {/snippet}
+    </SidebarItem>
+    <SidebarItem label="Sidebar" href="/components/sidebar" active={false}>
+    {#snippet iconSlot()}
+        <UserSolid class="h-5 w-5 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white" />
+    {/snippet}
+    </SidebarItem>
+</SidebarGroup>
+</Sidebar>


### PR DESCRIPTION
## 📑 Description
Allow the user to override the logic to select the active element in the navbar. This allows greater control over the active logic for advanced usecases. (For example if you have sub-pages but you just want to show a single element in the sidebar)

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
