### PR TITLE
fix: fix accordionitem open state

### DIFF
--- a/src/lib/accordion/AccordionItem.svelte
+++ b/src/lib/accordion/AccordionItem.svelte
@@ -12,23 +12,23 @@
   let inactiveCls = twMerge(inactiveClass, classInactive);
 
   const ctx = getContext<AccordionCtxType>('ctx') ?? {};
+  if (!ctx.selected){
+    ctx.selected = writable();
+  }
 
   // single selection
   const self = {};
-  const selected = ctx.selected ?? writable();
+  const selected = ctx.selected;
 
-  let _open: boolean = $state(open);
+  if (open) {
+    selected.set(self)
+  }
 
-  $effect(() => {
-    if (_open) $selected = self;
+  selected.subscribe((x) => (open = x === self));
 
-    // this will trigger unsubscribe on destroy
-    return selected.subscribe((x) => (open = x === self));
-  });
+  const handleToggle = (_: Event) =>  selected.set(open ? {} : self);
 
-  const handleToggle = (_: Event) => selected.set(open ? {} : self);
-
-  let buttonClass: string = twMerge(defaultClass, ctx.flush ? '' : borderClass, borderBottomClass, borderSharedClass, ctx.flush ? paddingFlush : paddingDefault, open && (ctx.flush ? textFlushOpen : activeCls || ctx.activeClass), !open && (ctx.flush ? textFlushDefault : inactiveCls || ctx.inactiveClass), className);
+  let buttonClass: string = $derived(twMerge(defaultClass, ctx.flush ? '' : borderClass, borderBottomClass, borderSharedClass, ctx.flush ? paddingFlush : paddingDefault, open && (ctx.flush ? textFlushOpen : activeCls || ctx.activeClass), !open && (ctx.flush ? textFlushDefault : inactiveCls || ctx.inactiveClass), className));
 
   let contentClass = twMerge([ctx.flush ? paddingFlush : paddingDefault, ctx.flush ? '' : borderOpenClass, borderBottomClass, borderSharedClass]);
 </script>

--- a/src/routes/pages/coverage/+page.svelte
+++ b/src/routes/pages/coverage/+page.svelte
@@ -27,7 +27,7 @@
     accordion: {
       checked: true,
       // notes: 'Variants'
-      problems: 'AlwaysOpen'
+      // problems: 'AlwaysOpen'
     },
     alert: {
       checked: true


### PR DESCRIPTION
## 📑 Description
Couple of fixes for the accordionitem open state: 
1. Update behaviour so it collapses other AccordianItems in the same group when you click an item. I believe this is the expected behaviour and fixes the "Always Open" issue on the coverage page.
2. Update behaviour to allow for an AccordianItem to start open - previously the item collapsed immediately even if the open parameter was set to true. Unsure if this needs a new doc example, please let me know

I've bundled the changes as they are small and related - please let me know if you would prefer multiple PRs :) 

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
There is some weird behaviour with the focus rings on the default style. When an AccordionItem moves to the "activeClass" it gains a focus ring - this overspills and looks slightly odd. I have not "fixed" this as it seems to be desired behaviour based on the default acitveClass. I believe this wasn't happening previously as the "activeClass" was never applying to the AccorionItem. 

Let me know what you think and if you want to keep the focus-ring / change the styling: 
![image](https://github.com/user-attachments/assets/4021f6bc-e003-455e-aabd-9e1f35fa1b19)
