### PR TITLE
fix: allow sidebar to have static positioning

### DIFF
--- a/src/lib/sidebar/theme.ts
+++ b/src/lib/sidebar/theme.ts
@@ -11,7 +11,8 @@ export const sidebar = tv({
   variants: {
     position: {
       fixed: { base: 'fixed' },
-      absolute: { base: 'absolute' }
+      absolute: { base: 'absolute' },
+      static: { base: 'static' }
     },
     isOpen: {
       true: 'block',

--- a/src/routes/components/sidebar/+page.svelte
+++ b/src/routes/components/sidebar/+page.svelte
@@ -29,7 +29,8 @@
     { name: 'Cta', component: ExampleComponents.Cta },
     { name: 'Logo branding', component: ExampleComponents.LogoBranding },
     { name: 'Logo branding with children', component: ExampleComponents.LogoBrandingWithChildren },
-    { name: 'Dropdown transition', component: ExampleComponents.DropdownTransition }
+    { name: 'Dropdown transition', component: ExampleComponents.DropdownTransition },
+    { name: 'Static positioning', component: ExampleComponents.StaticPositioning }
   ];
   let selectedExample: string | number = $state(exampleArr[0].name);
   let svelteCode = $derived(getExampleFileName(selectedExample, exampleArr));

--- a/src/routes/components/sidebar/examples/StaticPositioning.svelte
+++ b/src/routes/components/sidebar/examples/StaticPositioning.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { Sidebar, SidebarGroup, SidebarItem, SidebarButton, uiHelpers } from '$lib';
+  import { ChartOutline, GridSolid, MailBoxSolid, UserSolid } from 'flowbite-svelte-icons';
+  import PlusPlaceholder from '../../../utils/PlusPlaceholder.svelte';
+  const spanClass = 'flex-1 ms-3 whitespace-nowrap';
+  const demoSidebarUi = uiHelpers();
+  let isDemoOpen = $state(true);
+  const closeDemoSidebar = demoSidebarUi.close;
+  $effect(() => {
+    isDemoOpen = demoSidebarUi.isOpen;
+  });
+</script>
+
+<div class="h-96 overflow-scroll px-4">
+  <div class="rounded-lg border-2 border-dashed border-gray-200 p-4 dark:border-gray-700">
+    <div class="flex w-full flex-row pb-4">
+      <SidebarButton onclick={demoSidebarUi.toggle} class="mb-2" />
+      <Sidebar backdrop={false} isOpen={isDemoOpen} closeSidebar={closeDemoSidebar} params={{ x: -50, duration: 50 }} class="z-50" position="static" activeClass="p-2" nonActiveClass="p-2">
+        <SidebarGroup>
+          <SidebarItem label="Dashboard" href="/">
+            {#snippet iconSlot()}
+              <ChartOutline class="h-5 w-5 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white" />
+            {/snippet}
+          </SidebarItem>
+          <SidebarItem label="Kanban" {spanClass} href="/">
+            {#snippet iconSlot()}
+              <GridSolid class="h-5 w-5 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white" />
+            {/snippet}
+            {#snippet subtext()}
+              <span class="ms-3 inline-flex items-center justify-center rounded-full bg-gray-200 px-2 text-sm font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300">Pro</span>
+            {/snippet}
+          </SidebarItem>
+          <SidebarItem label="Inbox" {spanClass} href="/">
+            {#snippet iconSlot()}
+              <MailBoxSolid class="h-5 w-5 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white" />
+            {/snippet}
+            {#snippet subtext()}
+              <span class="ms-3 inline-flex h-3 w-3 items-center justify-center rounded-full bg-primary-200 p-3 text-sm font-medium text-primary-600 dark:bg-primary-900 dark:text-primary-200">3</span>
+            {/snippet}
+          </SidebarItem>
+          <SidebarItem label="Sidebar" href="/components/sidebar">
+            {#snippet iconSlot()}
+              <UserSolid class="h-5 w-5 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white" />
+            {/snippet}
+          </SidebarItem>
+        </SidebarGroup>
+      </Sidebar>
+      <div class="grow pl-4 pt-2">
+        <PlusPlaceholder colnum={2} rownum={2} />
+      </div>
+    </div>
+    <PlusPlaceholder />
+    <PlusPlaceholder colnum={3} rownum={1} />
+    <PlusPlaceholder />
+    <PlusPlaceholder colnum={2} rownum={2} />
+  </div>
+</div>

--- a/src/routes/components/sidebar/examples/index.ts
+++ b/src/routes/components/sidebar/examples/index.ts
@@ -10,3 +10,4 @@ export { default as LogoBranding } from './LogoBranding.svelte';
 export { default as LogoBrandingWithChildren } from './LogoBrandingWithChildren.svelte';
 export { default as DropdownTransition } from './DropdownTransition.svelte';
 export { default as CloseButton } from './CloseButton.svelte';
+export { default as StaticPositioning } from './StaticPositioning.svelte';


### PR DESCRIPTION
## 📑 Description
Allow `static` as one of the positions in the sidebar so that it can be used as a drop in component in any page. This is in addition to `fixed` and `absolute`. Please let me know if it does not make sense :)

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
