### PR TITLE
bugfix: remove backdrop if the backdrop variable is set to false

### DIFF
--- a/src/lib/drawer/Drawer.svelte
+++ b/src/lib/drawer/Drawer.svelte
@@ -23,8 +23,6 @@
     <div role="presentation" class={backdropCls({ class: backdropClass })}></div>
   {:else if !backdrop && activateClickOutside}
     <div role="presentation" class="fixed start-0 top-0 z-50 h-full w-full" onclick={closeDrawer}></div>
-  {:else if !backdrop && !activateClickOutside}
-    <div role="presentation" class="fixed start-0 top-0 z-50 h-full w-full"></div>
   {/if}
   <div {...restProps} class={base({ className })} transition:transition={params as ParamsType} tabindex="-1">
     {@render children()}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->


## 📑 Description

The current drawer component puts a backdrop div in the page even if the backdrop is set to false. I believe that if the `backdrop` variable is false the most desirable behaviour would be to do not add the backdrop div at all. This new behaviour might be useful if the drawer is used in a page where the user is allowed to copy paste some information in from other elements in the page that would otherwise be inaccessible.

The current component behaviour might be desirable in some cases (e.g. I want to have a drawer with a transparent backdrop so that the page is visible but I want to prevent the user from interacting with anything else) however this can still be achieved by setting `backdropClass="!bg-transparent"` when using the component.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

There are definitely multiple ways to achieve this. I think the one proposed in this PR might be the cleanest but I am happy to add an additional variable like `addBackdrop: boolean` if you prefer to maintain the current behaviour.
