### PR TITLE
Allow size on select

### DIFF
--- a/src/lib/forms/select/Select.svelte
+++ b/src/lib/forms/select/Select.svelte
@@ -4,9 +4,10 @@
   let { children, items, value = $bindable(), underline, size = "md", class: className, placeholder = "Choose option ...", ...restProps }: Props<T> = $props();
 
   const selectStyle = $derived(selectCls({ underline, size, className }));
+  const componentSize = $derived(Number(size)??undefined);
 </script>
 
-<select {...restProps} bind:value class={selectStyle}>
+<select {...restProps} bind:value class={selectStyle} size={componentSize}>
   {#if placeholder}
     <option disabled selected value="">{placeholder}</option>
   {/if}

--- a/src/lib/forms/select/index.ts
+++ b/src/lib/forms/select/index.ts
@@ -14,7 +14,7 @@ interface SelectProps<T> extends Omit<HTMLSelectAttributes, "size"> {
   children?: Snippet;
   items?: SelectOptionType<T>[];
   underline?: boolean;
-  size?: SelectSize;
+  size?: SelectSize | number;
   placeholder?: string;
 }
 


### PR DESCRIPTION
## 📑 Description
Allow select size to be a number reflecting the original select props.

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [] My code requires changes to the documentation
- [] I have updated the documentation as required
- [ ] All the tests have passed
